### PR TITLE
Upload-file addtional parameters

### DIFF
--- a/pyseaweed/seaweed.py
+++ b/pyseaweed/seaweed.py
@@ -155,7 +155,7 @@ class SeaweedFS(object):
         url = self.get_file_url(fid)
         return self.conn.delete_data(url)
 
-    def upload_file(self, path=None, stream=None, name=None, additional_headers=None, **kwargs):
+    def upload_file(self, path=None, stream=None, name=None, additional_headers=None, content_type=None, **kwargs):
         """
         Uploads file to SeaweedFS
 
@@ -168,6 +168,7 @@ class SeaweedFS(object):
         :param string stream:
         :param string name:
         :param dict additional_headers:
+        :param string content_type:
         :rtype: string or None
 
         """
@@ -189,10 +190,10 @@ class SeaweedFS(object):
         if path is not None:
             filename = os.path.basename(path) if name is None else name
             with open(path, "rb") as file_stream:
-                res = self.conn.post_file(post_url, filename, file_stream, additional_headers=additional_headers)
+                res = self.conn.post_file(post_url, filename, file_stream, additional_headers=additional_headers, content_type=content_type)
         # we have file like object and filename
         elif stream is not None and name is not None:
-            res = self.conn.post_file(post_url, name, stream, additional_headers=additional_headers)
+            res = self.conn.post_file(post_url, name, stream, additional_headers=additional_headers, content_type=content_type)
         else:
             raise ValueError(
                 "If `path` is None then *both* `stream` and `name` must not"

--- a/pyseaweed/utils.py
+++ b/pyseaweed/utils.py
@@ -113,7 +113,7 @@ class Connection(object):
         """
         res = self._conn.post(
             url,
-            files={filename: file_stream},
+            files={'file': (filename, file_stream)},
             headers=self._prepare_headers(**kwargs),
         )
         if res.status_code == 200 or res.status_code == 201:

--- a/pyseaweed/utils.py
+++ b/pyseaweed/utils.py
@@ -92,7 +92,7 @@ class Connection(object):
         else:
             return None
 
-    def post_file(self, url, filename, file_stream, *args, **kwargs):
+    def post_file(self, url, filename, file_stream, content_type=None, *args, **kwargs):
         """Uploads file to provided url.
 
         Returns contents as text
@@ -104,6 +104,8 @@ class Connection(object):
 
             **file_stream**: file like object to upload
 
+            **content_type**: (optional) Content type of the file
+
             .. versionadded:: 0.3.2
                 **additional_headers**: (optional) Additional headers
                 to be used with request
@@ -113,7 +115,7 @@ class Connection(object):
         """
         res = self._conn.post(
             url,
-            files={'file': (filename, file_stream)},
+            files={'file': (filename, file_stream) if content_type is None else (filename, file_stream, content_type)},
             headers=self._prepare_headers(**kwargs),
         )
         if res.status_code == 200 or res.status_code == 201:


### PR DESCRIPTION
Right now, it's not possible to set the content type of an uploaded file or add additional header parameters as described in https://github.com/seaweedfs/seaweedfs/wiki/Volume-Server-API

This fixes also in upload_file if path and name are set, the name is ignored and the filename of path used instead.